### PR TITLE
FILE-104 Fixed incorrect name of a downloaded file.

### DIFF
--- a/app/uk/gov/hmrc/fileupload/controllers/FileController.scala
+++ b/app/uk/gov/hmrc/fileupload/controllers/FileController.scala
@@ -59,7 +59,7 @@ class FileController(uploadBodyParser: (EnvelopeId, FileId) => BodyParser[Future
 
   def downloadFile(envelopeId: EnvelopeId, fileId: FileId) = Action.async { request =>
     retrieveFile(envelopeId, fileId).map {
-      case Xor.Right(FileFoundResult(filename, length, data)) =>
+      case Xor.Right(FileFound(filename, length, data)) =>
         Ok.feed(data).withHeaders(
           CONTENT_LENGTH -> s"${ length }",
           CONTENT_DISPOSITION -> s"""attachment; filename="${ filename.getOrElse("data") }""""

--- a/app/uk/gov/hmrc/fileupload/envelope/Service.scala
+++ b/app/uk/gov/hmrc/fileupload/envelope/Service.scala
@@ -32,33 +32,33 @@ object Service {
   type UpsertFileResult = Xor[UpsertFileError, Envelope]
 
   type UpdateMetadataResult = Xor[UpdateMetadataError, UpdateMetadataSuccess.type]
-  object UpdateMetadataSuccess
+  case object UpdateMetadataSuccess
 
   sealed trait CreateError
   case class CreateNotSuccessfulError(envelope: Envelope) extends CreateError
   case class CreateServiceError(envelope: Envelope, message: String) extends CreateError
 
   sealed trait FindError
-  object FindEnvelopeNotFoundError extends FindError
+  case object FindEnvelopeNotFoundError extends FindError
   case class FindServiceError(message: String) extends FindError
 
   sealed trait DeleteError
-  object DeleteEnvelopeNotFoundError extends DeleteError
-  object DeleteEnvelopeNotSuccessfulError extends DeleteError
+  case object DeleteEnvelopeNotFoundError extends DeleteError
+  case object DeleteEnvelopeNotSuccessfulError extends DeleteError
   case class DeleteServiceError(message: String) extends DeleteError
 
   sealed trait UpsertFileError
-  object UpsertFileEnvelopeNotFoundError extends UpsertFileError
+  case object UpsertFileEnvelopeNotFoundError extends UpsertFileError
   case class UpsertFileServiceError(message: String) extends UpsertFileError
-  object UpsertFileUpdatingEnvelopeFailed extends UpsertFileError
+  case object UpsertFileUpdatingEnvelopeFailed extends UpsertFileError
 
   sealed trait UpdateMetadataError
-  object UpdateMetadataEnvelopeNotFoundError extends UpdateMetadataError
-  object UpdateMetadataNotSuccessfulError extends UpdateMetadataError
+  case object UpdateMetadataEnvelopeNotFoundError extends UpdateMetadataError
+  case object UpdateMetadataNotSuccessfulError extends UpdateMetadataError
   case class UpdateMetadataServiceError(message: String) extends UpdateMetadataError
 
   type UpsertFileToEnvelopeResult = UpsertFileError Xor UpsertFileSuccess.type
-  object UpsertFileSuccess
+  case object UpsertFileSuccess
 
   case class UploadedFileInfo(envelopeId: EnvelopeId,
                               fileId: FileId,
@@ -107,7 +107,7 @@ object Service {
                     (implicit ex: ExecutionContext): Future[UpdateMetadataResult] = {
     getEnvelope(envelopeId).flatMap {
       case Some(envelope) =>
-        val updatedEnvelope = envelope.addMetadata(fileId = fileId, name = name, contentType = contentType, metadata = metadata)
+        val updatedEnvelope = envelope.addMetadataToAFile(fileId = fileId, name = name, contentType = contentType, metadata = metadata)
         updateEnvelope(updatedEnvelope).map {
           case true => Xor.right(UpdateMetadataSuccess)
           case false => Xor.left(UpdateMetadataNotSuccessfulError)

--- a/app/uk/gov/hmrc/fileupload/envelope/model.scala
+++ b/app/uk/gov/hmrc/fileupload/envelope/model.scala
@@ -16,12 +16,10 @@
 
 package uk.gov.hmrc.fileupload.envelope
 
-import java.util.UUID
-
 import org.joda.time.DateTime
 import play.api.libs.json.{Format, JsObject, _}
-import uk.gov.hmrc.fileupload.{EnvelopeId, FileId}
 import uk.gov.hmrc.fileupload.envelope.Service.UploadedFileInfo
+import uk.gov.hmrc.fileupload.{EnvelopeId, FileId}
 
 case class Envelope(_id: EnvelopeId = EnvelopeId(),
                     constraints: Option[Constraints] = None,
@@ -45,9 +43,8 @@ case class Envelope(_id: EnvelopeId = EnvelopeId(),
     add(file)
   }
 
-  def addMetadata(fileId: FileId, name: Option[String] = None, contentType: Option[String] = None,
-                  length: Option[Long] = None, uploadDate: Option[DateTime] = None,
-                  revision: Option[Int] = None, metadata: Option[JsObject] = None): Envelope = {
+  def addMetadataToAFile(fileId: FileId, name: Option[String] = None, contentType: Option[String] = None,
+                         revision: Option[Int] = None, metadata: Option[JsObject] = None): Envelope = {
 
     val file = files.flatMap(_.collectFirst {
       case f if f.fileId == fileId =>

--- a/test/uk/gov/hmrc/fileupload/envelope/EnvelopeSpec.scala
+++ b/test/uk/gov/hmrc/fileupload/envelope/EnvelopeSpec.scala
@@ -183,7 +183,7 @@ class EnvelopeSpec extends UnitSpec {
     val fileId = FileId("newfile")
     val name = "test"
     val metadata: JsObject = Json.obj("a" -> "v")
-    val envelope = Envelope().addMetadata(fileId = fileId, name = Some(name), metadata = Some(metadata))
+    val envelope = Envelope().addMetadataToAFile(fileId = fileId, name = Some(name), metadata = Some(metadata))
 
     envelope.files shouldBe Some(Seq(File(fileId = fileId, name = Some(name), metadata = Some(metadata))))
   }
@@ -194,7 +194,7 @@ class EnvelopeSpec extends UnitSpec {
     val name = "test"
     val metadata: JsObject = Json.obj("a" -> "v")
 
-    val envelope = Envelope(files = Some(Seq(oldFile))).addMetadata(fileId = fileId, name = Some(name), metadata = Some(metadata))
+    val envelope = Envelope(files = Some(Seq(oldFile))).addMetadataToAFile(fileId = fileId, name = Some(name), metadata = Some(metadata))
 
     envelope.files shouldBe Some(Seq(oldFile, File(fileId = fileId, name = Some(name), metadata = Some(metadata))))
   }
@@ -208,7 +208,7 @@ class EnvelopeSpec extends UnitSpec {
     val newName = "newtest"
     val newMetadata = Json.obj("a" -> "newV")
     val otherFile = File(fileId = FileId("otherFile"))
-    val envelope = Envelope(files = Some(Seq(otherFile, file))).addMetadata(fileId = fileId, name = Some(newName), metadata = Some(newMetadata))
+    val envelope = Envelope(files = Some(Seq(otherFile, file))).addMetadataToAFile(fileId = fileId, name = Some(newName), metadata = Some(newMetadata))
 
     envelope.files shouldBe Some(Seq(otherFile, File(fileId = fileId, name = Some(newName), metadata = Some(newMetadata))))
   }


### PR DESCRIPTION
If client specifies file name in the metadata the name should be used
as a file name when downloading. Otwerwise string `data` should be used.