### PR TITLE
Fix Kibana logging issues after upgrade to 2.5 

### DIFF
--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -43,7 +43,7 @@ private object AppDependencies {
     "uk.gov.hmrc" %% "play-url-binders" % playUrlBindersVersion,
     "uk.gov.hmrc" %% "play-config" % playConfigVersion,
     "uk.gov.hmrc" %% "play-auditing" % playAuditing,
-    "uk.gov.hmrc" %% "logback-json-logger" % playJsonLoggerVersion,
+    "uk.gov.hmrc" %% "play-json-logger" % playJsonLoggerVersion,
     "uk.gov.hmrc" %% "domain" % domainVersion,
     "com.typesafe.akka" % "akka-actor_2.11" % akkaVersion,
     "com.typesafe.akka" % "akka-testkit_2.11" % akkaVersion,


### PR DESCRIPTION
Revert back to old json logger, with the newer lib logs will not be tagged with the app name in kibana