### PR TITLE
PLATOPS-1462: Upgrade to latest reactivemongo

### DIFF
--- a/app/uk/gov/hmrc/fileupload/ApplicationLoader.scala
+++ b/app/uk/gov/hmrc/fileupload/ApplicationLoader.scala
@@ -131,7 +131,7 @@ class ApplicationModule(context: Context) extends BuiltInComponentsFromContext(c
     }
   }
 
-  lazy val db = new ReactiveMongoComponentImpl(application, applicationLifecycle).mongoConnector.db
+  lazy val db = new ReactiveMongoComponentImpl(configuration, environment, applicationLifecycle).mongoConnector.db
 
   // notifier
   actorSystem.actorOf(NotifierActor.props(subscribe, findEnvelope, sendNotification), "notifierActor")

--- a/app/uk/gov/hmrc/fileupload/package.scala
+++ b/app/uk/gov/hmrc/fileupload/package.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc
 
 import _root_.play.api.libs.json.JsValue
 import reactivemongo.api.gridfs.{GridFS, ReadFile}
-import reactivemongo.json.JSONSerializationPack
+import reactivemongo.play.json.JSONSerializationPack
 
 import scala.concurrent.Future
 import scala.util.Try

--- a/app/uk/gov/hmrc/fileupload/read/envelope/Repository.scala
+++ b/app/uk/gov/hmrc/fileupload/read/envelope/Repository.scala
@@ -26,6 +26,7 @@ import reactivemongo.api.indexes.{Index, IndexType}
 import reactivemongo.api.{DB, DBMetaCommands, ReadPreference}
 import reactivemongo.bson.BSONObjectID
 import reactivemongo.core.errors.DatabaseException
+import reactivemongo.play.json.ImplicitBSONHandlers
 import uk.gov.hmrc.fileupload.EnvelopeId
 import uk.gov.hmrc.mongo.ReactiveRepository
 
@@ -61,6 +62,7 @@ class Repository(mongo: () => DB with DBMetaCommands)
     collection.indexesManager.ensure(Index(key = List("status" -> IndexType.Ascending, "destination" -> IndexType.Ascending), background = true)).map(Seq(_))
   }
 
+  import ImplicitBSONHandlers._
   import Repository._
 
   def update(writeConcern: WriteConcern = WriteConcern.Default)

--- a/app/uk/gov/hmrc/fileupload/read/file/Repository.scala
+++ b/app/uk/gov/hmrc/fileupload/read/file/Repository.scala
@@ -27,7 +27,7 @@ import reactivemongo.api.indexes.Index
 import reactivemongo.api.indexes.IndexType.Ascending
 import reactivemongo.api.{DB, DBMetaCommands}
 import reactivemongo.bson.{BSONDateTime, BSONDocument}
-import reactivemongo.json._
+import reactivemongo.play.json._
 import uk.gov.hmrc.fileupload._
 
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -56,7 +56,7 @@ object FileInfo {
 
 class Repository(mongo: () => DB with DBMetaCommands)(implicit ec: ExecutionContext) {
 
-  import reactivemongo.json.collection._
+  import reactivemongo.play.json.collection._
 
   lazy val gfs: JSONGridFS = GridFS[JSONSerializationPack.type](mongo(), "envelopes")
 

--- a/app/uk/gov/hmrc/fileupload/write/infrastructure/EventSerializer.scala
+++ b/app/uk/gov/hmrc/fileupload/write/infrastructure/EventSerializer.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.fileupload.write.infrastructure
 
 import play.api.libs.json._
 import reactivemongo.bson.{BSONArray, BSONDocument, BSONDocumentReader, BSONDocumentWriter}
-import reactivemongo.json.BSONFormats
+import reactivemongo.play.json.BSONFormats
 
 object EventSerializer {
 

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -21,15 +21,13 @@ private object AppDependencies {
   private val microserviceBootstrapVersion = "6.18.0"
   private val domainVersion = "4.1.0"
   private val hmrcTestVersion = "2.4.0"
-  private val playReactivemongoVersion = "5.2.0"
-  private val simpleReactivemongoVersion = "5.2.0"
+  private val playReactivemongoVersion = "6.2.0"
   private val akkaVersion = "2.4.10"
   private val catsVersion = "0.7.0"
   private val authClientVersion = "2.1.0"
 
   val compile = Seq(
     "uk.gov.hmrc" %% "play-reactivemongo" % playReactivemongoVersion,
-    "uk.gov.hmrc" %% "simple-reactivemongo" % simpleReactivemongoVersion,
     ws,
     "uk.gov.hmrc" %% "microservice-bootstrap" % microserviceBootstrapVersion,
     "uk.gov.hmrc" %% "auth-client" % authClientVersion,


### PR DESCRIPTION
MDTP will soon migrate to mongo 3.4 and this PR upgrades reactive mongo to version that works with mongo 3.4