### PR TITLE
PLATY 809 - Logging warnings when someone creates envelope with non-HTTPS callback url

### DIFF
--- a/app/uk/gov/hmrc/fileupload/controllers/EnvelopeController.scala
+++ b/app/uk/gov/hmrc/fileupload/controllers/EnvelopeController.scala
@@ -16,10 +16,12 @@
 
 package uk.gov.hmrc.fileupload.controllers
 
+import java.net.URL
 import java.time.Duration
 
 import akka.stream.scaladsl.Source.fromPublisher
 import cats.data.Xor
+import cats.syntax.either._
 import org.joda.time.DateTime
 import play.api.Logger
 import play.api.libs.iteratee.Enumerator
@@ -39,6 +41,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import uk.gov.hmrc.http.BadRequestException
 
+import scala.util.{Failure, Success, Try}
+
 class EnvelopeController(withBasicAuth: BasicAuth,
                          nextId: () => EnvelopeId,
                          handleCommand: (EnvelopeCommand) => Future[Xor[CommandNotAccepted, CommandAccepted.type]],
@@ -54,31 +58,45 @@ class EnvelopeController(withBasicAuth: BasicAuth,
   def create() = Action.async(jsonBodyParser[CreateEnvelopeRequest]) { implicit request =>
     def envelopeLocation = (id: EnvelopeId) => LOCATION -> s"${ request.host }${ uk.gov.hmrc.fileupload.controllers.routes.EnvelopeController.show(id) }"
 
-    val validatedUserEnvelopeConstraints = validatedEnvelopeFilesConstraints(request)
-
-    validatedUserEnvelopeConstraints match {
-      case Right(envelopeConstraints: EnvelopeFilesConstraints) ⇒
-
-        val expiryTimes = durationsToDateTime(envelopeConstraintsConfigure.defaultExpirationDuration, envelopeConstraintsConfigure.maxExpirationDuration)
-
-        val userExpiryDate = request.body.expiryDate.orElse(Some(expiryTimes.default))
-
-        validateExpiryDate(expiryTimes.now, expiryTimes.max, userExpiryDate.get) match {
-          case Some(error) =>
-            Logger.warn(s"Bad expiryDate detected. user time: ${userExpiryDate.get}," +
-              s" configuration: $expiryTimes," +
-              s" user-agent: ${request.headers.get("User-Agent")}")
-            Future.successful(BadRequestHandler(new BadRequestException(error.message)))
-          case None =>
-            val command = CreateEnvelope(nextId(), request.body.callbackUrl, userExpiryDate, request.body.metadata, Some(envelopeConstraints))
-            val userAgent = request.headers.get("User-Agent").getOrElse("none")
-            Logger.info(s"""envelopeId=${command.id} User-Agent=$userAgent""")
-            handleCreate(envelopeLocation, command)
-        }
-      case Left(failureReason: ConstraintsValidationFailure) ⇒
-        Future.successful(BadRequestHandler(new BadRequestException(s"${failureReason.message}")))
+    val result = for {
+      envelopeConstraints <- validatedEnvelopeFilesConstraints(request).right
+      expiryTimes = durationsToDateTime(envelopeConstraintsConfigure.defaultExpirationDuration, envelopeConstraintsConfigure.maxExpirationDuration)
+      userExpiryDate = request.body.expiryDate.orElse(Some(expiryTimes.default))
+      _ <- validateExpiryDate(expiryTimes.now, expiryTimes.max, userExpiryDate.get).right
+      _ <- validateCallbackUrl(request)
+    } yield {
+      val command = CreateEnvelope(nextId(), request.body.callbackUrl, userExpiryDate, request.body.metadata, Some(envelopeConstraints))
+      val userAgent = request.headers.get("User-Agent").getOrElse("none")
+      Logger.info(s"""envelopeId=${command.id} User-Agent=$userAgent""")
+      handleCreate(envelopeLocation, command)
     }
+
+
+    result match {
+      case Right(successfulResult) =>
+        successfulResult
+      case Left(error) =>
+        Logger.warn(s"Validation error. user time: ${error}, user-agent: ${request.headers.get("User-Agent")}")
+        Future.successful(BadRequestHandler(new BadRequestException(s"${error.message}")))
+    }
+
   }
+
+  private def validateCallbackUrl(request: Request[CreateEnvelopeRequest]): Either[InvalidCallbackUrl, Unit] = {
+
+    val allowedProtocols = Seq("https")
+
+    request.body.callbackUrl match {
+      case None => Right()
+      case Some(url) =>
+        for {
+          parsedUrl <- Either.catchNonFatal(new URL(url)).leftMap(_ => InvalidCallbackUrl(url))
+          _ <- if (allowedProtocols.contains(parsedUrl.getProtocol)) Right() else Left(InvalidCallbackUrl(url))
+        } yield ()
+    }
+
+  }
+
 
   def createWithId(id: EnvelopeId) = Action.async(jsonBodyParser[CreateEnvelopeRequest]) { implicit request =>
     def envelopeLocation = (id: EnvelopeId) => LOCATION -> s"${ request.host }${ uk.gov.hmrc.fileupload.controllers.routes.EnvelopeController.show(id) }"

--- a/app/uk/gov/hmrc/fileupload/controllers/EnvelopeController.scala
+++ b/app/uk/gov/hmrc/fileupload/controllers/EnvelopeController.scala
@@ -96,8 +96,8 @@ class EnvelopeController(withBasicAuth: BasicAuth,
     }
 
     //Temporarily only log errors and pass validation
-    result.left.flatMap(invalidUrl => {
-      Logger.error(s"Service with user-agent: [${request.headers.get("User-Agent")}] send invalid callback URL [$request.body.callbackUrl]")
+    result.left.flatMap(_ => {
+      Logger.warn(s"Service with user-agent: [${request.headers.get("User-Agent")}] send invalid callback URL [$request.body.callbackUrl]")
       Right(())
     })
 

--- a/app/uk/gov/hmrc/fileupload/controllers/EnvelopeFilesConstraints.scala
+++ b/app/uk/gov/hmrc/fileupload/controllers/EnvelopeFilesConstraints.scala
@@ -80,5 +80,5 @@ case object InvalidExpiryDate extends ConstraintsValidationFailure {
 }
 
 case class InvalidCallbackUrl(url : String) extends ConstraintsValidationFailure {
-  override def message: String = s"invalid callback URL + $url"
+  override def message: String = s"invalid callback URL [$url]"
 }

--- a/app/uk/gov/hmrc/fileupload/controllers/EnvelopeFilesConstraints.scala
+++ b/app/uk/gov/hmrc/fileupload/controllers/EnvelopeFilesConstraints.scala
@@ -78,3 +78,7 @@ case object InvalidFormat extends ConstraintsValidationFailure {
 case object InvalidExpiryDate extends ConstraintsValidationFailure {
   override def message: String = s"expiry date is not valid. It should be after now and before the max limit"
 }
+
+case class InvalidCallbackUrl(url : String) extends ConstraintsValidationFailure {
+  override def message: String = s"invalid callback URL + $url"
+}

--- a/app/uk/gov/hmrc/fileupload/infrastructure/EnvelopeConstraintsConfiguration.scala
+++ b/app/uk/gov/hmrc/fileupload/infrastructure/EnvelopeConstraintsConfiguration.scala
@@ -71,7 +71,7 @@ object EnvelopeConstraintsConfiguration {
       getFileConstraintsFromConfig(keyPrefix = "constraints.default")
 
     validateExpiryDate(times.now, times.max, times.default) match {
-      case None =>
+      case Right(_) =>
         for {
           accepted ← acceptedEnvelopeConstraints.right
           default ← defaultEnvelopeConstraints.right
@@ -81,7 +81,7 @@ object EnvelopeConstraintsConfiguration {
           maxExpiryDuration,
           defaultExpiryDuration
         )
-      case Some(error) => Left(error)
+      case Left(error) => Left(error)
     }
   }
 
@@ -123,12 +123,14 @@ object EnvelopeConstraintsConfiguration {
     userEnvelopeConstraints
   }
 
-  def validateExpiryDate(now: DateTime, max: DateTime, userExpiryDate: DateTime): Option[InvalidExpiryDate.type] = {
+  def validateExpiryDate(now: DateTime, max: DateTime, userExpiryDate: DateTime): Either[InvalidExpiryDate.type, Unit] = {
     if(now.isAfter(userExpiryDate) || userExpiryDate.isAfter(max))
-      Some(InvalidExpiryDate)
+      Left(InvalidExpiryDate)
     else
-      None
+      Right(())
   }
+
+
   def durationsToDateTime(default: Duration, max: Duration): ExpiryTimes = {
     val now = DateTime.now()
     def expiryDateFromDuration(dur: Duration) = now.plus(dur.toMillis)

--- a/test/uk/gov/hmrc/fileupload/controllers/EnvelopeControllerSpec.scala
+++ b/test/uk/gov/hmrc/fileupload/controllers/EnvelopeControllerSpec.scala
@@ -97,7 +97,7 @@ class EnvelopeControllerSpec extends UnitSpec with ApplicationComponents with Sc
     }
   }
 
-  "Create envelope with unsupported callback url protocol" should  {
+  "Create envelope with unsupported callback url protocol" ignore {
     "return response with OK status" in {
       val serverUrl = "http://production.com:8000"
 
@@ -113,7 +113,7 @@ class EnvelopeControllerSpec extends UnitSpec with ApplicationComponents with Sc
     }
   }
 
-  "Create envelope with malformed callback url protocol" should  {
+  "Create envelope with malformed callback url protocol" ignore {
     "return response with BAD_REQUEST status" in {
       val serverUrl = "http://production.com:8000"
 


### PR DESCRIPTION
Failing the request implemented as well - just disabled